### PR TITLE
Fixed page numbering

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ This is a template for formatting a dissertation in LaTeX according to the Unive
 # Usage
 Most of the directions are contained in the various files. Fill in the dissertation template and approval page template according to the comments. Once the approval page is built copy the .pdf to the main directory, the one containing main.tex. 
 
-Put the individual chapters in the same directory as main.tex without compiling them. There is an example chatper included in this project called theoriesOfMeaning.tex. 
+Put the individual chapters in the same directory as main.tex without compiling them. There is an example chapter included in this project called theoriesOfMeaning.tex.  
 
-Because this template uses the standalone package the preamble that is required for compiling any chapter, if it were to be its own LaTeX document is put in the preamble for main. For example, if Chapter 6 requires the package tikz, do not put \usepackage{tikz} in the preamble of chapter-6.tex, but instead in the preamble of main.tex. 
+The preamble for main should include all packages needed for every chapter. For example, if Chapter 6 requires the package tikz, do not put \usepackage{tikz} in the preamble of chapter-6.tex, but instead in the preamble of main.tex. 

--- a/main.tex
+++ b/main.tex
@@ -93,12 +93,13 @@ WRITE A PREFACE HERE
 \tableofcontents
 
 
-\pagenumbering{arabic}
+
 
 %Here is where you put the chapters of your dissertation. The general format is: 
 
 \chapter{Theories of Meaning}
 \label{chp:theories_of_meaning}
+\pagenumbering{arabic}
 \input{theoriesOfMeaning.tex}
 
 %where theoriesOfMeaning.tex is a tex file in the same directory as this file. 


### PR DESCRIPTION
Moved \pagenumbering{arabic} to after first chapter to fix where page 1 appears. Old version had page 1 on last page of TOC